### PR TITLE
bugfix: map key set to URL instead of pointer to URL

### DIFF
--- a/internal/cookies/cookiejar.go
+++ b/internal/cookies/cookiejar.go
@@ -96,7 +96,7 @@ func kookies2cookies(kookies []*kooky.Cookie, filters ...kooky.Filter) []*http.C
 }
 
 func setAllCookies(jar http.CookieJar, cookies []*http.Cookie) {
-	cookieMap := make(map[*url.URL][]*http.Cookie)
+	cookieMap := make(map[url.URL][]*http.Cookie)
 
 	for _, c := range cookies {
 		if c == nil {
@@ -109,7 +109,7 @@ func setAllCookies(jar http.CookieJar, cookies []*http.Cookie) {
 		} else {
 			scheme = `http`
 		}
-		u := &url.URL{
+		u := url.URL{
 			Scheme: scheme,
 			Host:   c.Domain,
 			Path:   c.Path,
@@ -123,6 +123,6 @@ func setAllCookies(jar http.CookieJar, cookies []*http.Cookie) {
 	}
 
 	for u, cs := range cookieMap {
-		jar.SetCookies(u, cs)
+		jar.SetCookies(&u, cs)
 	}
 }


### PR DESCRIPTION
in the following code, the keys to the map were set to be *url.URL (pointers to URL); every iteration of the range loop it would create a new instance of the URL struct with a new pointer associated with it, and use that as the key to the map.  In doing so, no two keys (pointers) would be the same even if the underlying URL were the same.  

For example, if the cookie slice passed to that method contained 15 cookies all with the same scheme/domain/path, the resulting map would contain 15 keys and 15 arrays of cookies, each array containing one cookie each.  This would then cause jar.SetCookies() to be called 15 times.

The simple fix is to use a concrete struct as the map key (one that can be comparable for map keys); with this fix the above example would cause the map to have one entry with an array of 15 cookies, causing jar.SetCookies() to be called only once.