### PR TITLE
Add support for Brave Browser

### DIFF
--- a/browser/all/import.go
+++ b/browser/all/import.go
@@ -1,6 +1,7 @@
 package all
 
 import (
+	_ "github.com/browserutils/kooky/browser/brave"
 	_ "github.com/browserutils/kooky/browser/browsh"
 	_ "github.com/browserutils/kooky/browser/chrome"
 	_ "github.com/browserutils/kooky/browser/chromium"

--- a/browser/brave/brave.go
+++ b/browser/brave/brave.go
@@ -1,0 +1,30 @@
+package brave
+
+import (
+	"context"
+
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+func ReadCookies(ctx context.Context, filename string, filters ...kooky.Filter) ([]*kooky.Cookie, error) {
+	return cookies.SingleRead(cookieStore, filename, filters...).ReadAllCookies(ctx)
+}
+
+func TraverseCookies(filename string, filters ...kooky.Filter) kooky.CookieSeq {
+	return cookies.SingleRead(cookieStore, filename, filters...)
+}
+
+// CookieStore has to be closed with CookieStore.Close() after use.
+func CookieStore(filename string, filters ...kooky.Filter) (kooky.CookieStore, error) {
+	return cookieStore(filename, filters...)
+}
+
+func cookieStore(filename string, filters ...kooky.Filter) (*cookies.CookieJar, error) {
+	s := &chrome.CookieStore{}
+	s.FileNameStr = filename
+	s.BrowserStr = `brave`
+
+	return cookies.NewCookieJar(s, filters...), nil
+}

--- a/browser/brave/find.go
+++ b/browser/brave/find.go
@@ -1,0 +1,43 @@
+package brave
+
+import (
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	"github.com/browserutils/kooky/internal/chrome/find"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+type braveFinder struct{}
+
+var _ kooky.CookieStoreFinder = (*braveFinder)(nil)
+
+func init() {
+	kooky.RegisterFinder(`brave`, &braveFinder{})
+}
+
+func (f *braveFinder) FindCookieStores() kooky.CookieStoreSeq {
+	return func(yield func(kooky.CookieStore, error) bool) {
+		for file, err := range find.FindBraveCookieStoreFiles() {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			st := &cookies.CookieJar{
+				CookieStore: &chrome.CookieStore{
+					DefaultCookieStore: cookies.DefaultCookieStore{
+						BrowserStr:           file.Browser,
+						ProfileStr:           file.Profile,
+						OSStr:                file.OS,
+						IsDefaultProfileBool: file.IsDefaultProfile,
+						FileNameStr:          file.Path,
+					},
+				},
+			}
+			if !yield(st, nil) {
+				return
+			}
+		}
+	}
+}

--- a/internal/chrome/find/find.go
+++ b/internal/chrome/find/find.go
@@ -26,6 +26,10 @@ func FindChromiumCookieStoreFiles() iter.Seq2[*chromeCookieStoreFile, error] {
 	return FindCookieStoreFiles(chromiumRoots, `chromium`)
 }
 
+func FindBraveCookieStoreFiles() iter.Seq2[*chromeCookieStoreFile, error] {
+	return FindCookieStoreFiles(braveRoots, `brave`)
+}
+
 func FindCookieStoreFiles(rootsFunc iter.Seq2[string, error], browserName string) iter.Seq2[*chromeCookieStoreFile, error] {
 	return func(yield func(*chromeCookieStoreFile, error) bool) {
 		if rootsFunc == nil {

--- a/internal/chrome/find/find_android.go
+++ b/internal/chrome/find/find_android.go
@@ -15,3 +15,5 @@ func chromeRoots(yield func(string, error) bool) {
 }
 
 func chromiumRoots(yield func(string, error) bool) { _ = yield(``, errNotImplemented) }
+
+func braveRoots(yield func(string, error) bool) { _ = yield(``, errNotImplemented) }

--- a/internal/chrome/find/find_darwin.go
+++ b/internal/chrome/find/find_darwin.go
@@ -35,3 +35,15 @@ func chromiumRoots(yield func(string, error) bool) {
 		return
 	}
 }
+
+func braveRoots(yield func(string, error) bool) {
+	// "$HOME/Library/Application Support"
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		_ = yield(``, err)
+		return
+	}
+	if !yield(filepath.Join(cfgDir, `BraveSoftware`, `Brave-Browser`), nil) {
+		return
+	}
+}

--- a/internal/chrome/find/find_others.go
+++ b/internal/chrome/find/find_others.go
@@ -9,3 +9,5 @@ var errNotImplemented = errors.New(`not implemented`)
 func chromeRoots(yield func(string, error) bool) { _ = yield(``, errNotImplemented) }
 
 func chromiumRoots(yield func(string, error) bool) { _ = yield(``, errNotImplemented) }
+
+func braveRoots(yield func(string, error) bool) { _ = yield(``, errNotImplemented) }

--- a/internal/chrome/find/find_otherunix.go
+++ b/internal/chrome/find/find_otherunix.go
@@ -9,3 +9,7 @@ func windowsChromeRoots(_ string) func(yield func(string, error) bool) {
 func windowsChromiumRoots(_ string) func(yield func(string, error) bool) {
 	return func(yield func(string, error) bool) {}
 }
+
+func windowsBraveRoots(_ string) func(yield func(string, error) bool) {
+	return func(yield func(string, error) bool) {}
+}

--- a/internal/chrome/find/find_windows.go
+++ b/internal/chrome/find/find_windows.go
@@ -10,4 +10,5 @@ import (
 var (
 	chromeRoots   = windowsChromeRoots(os.Getenv(`LocalAppData`))
 	chromiumRoots = windowsChromiumRoots(os.Getenv(`LocalAppData`))
+	braveRoots    = windowsBraveRoots(os.Getenv(`LocalAppData`))
 )

--- a/internal/chrome/find/find_wsl.go
+++ b/internal/chrome/find/find_wsl.go
@@ -38,3 +38,15 @@ func windowsChromiumRoots(dir string) func(yield func(string, error) bool) {
 		}
 	}
 }
+
+func windowsBraveRoots(dir string) func(yield func(string, error) bool) {
+	return func(yield func(string, error) bool) {
+		if len(dir) == 0 {
+			_ = yield(``, errors.New(`%LocalAppData% is empty`))
+			return
+		}
+		if !yield(filepath.Join(dir, `BraveSoftware`, `Brave-Browser`, `User Data`), nil) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
Adds support for Brave Browser, following the same pattern already used for Chrome and Chromium browsers.

Changes: 
- Added a `brave` package
- Registered Brave as a browser in the all import
- Added `braveRoots` for MacOS, Linux, and Windows