### PR TITLE
Add Arc browser support on macOS

### DIFF
--- a/browser/all/import.go
+++ b/browser/all/import.go
@@ -2,6 +2,7 @@
 package all
 
 import (
+	_ "github.com/browserutils/kooky/browser/arc"
 	_ "github.com/browserutils/kooky/browser/brave"
 	_ "github.com/browserutils/kooky/browser/browsh"
 	_ "github.com/browserutils/kooky/browser/chrome"

--- a/browser/all/import.go
+++ b/browser/all/import.go
@@ -6,6 +6,7 @@ import (
 	_ "github.com/browserutils/kooky/browser/browsh"
 	_ "github.com/browserutils/kooky/browser/chrome"
 	_ "github.com/browserutils/kooky/browser/chromium"
+	_ "github.com/browserutils/kooky/browser/dia"
 	_ "github.com/browserutils/kooky/browser/dillo"
 	_ "github.com/browserutils/kooky/browser/edge"
 	_ "github.com/browserutils/kooky/browser/elinks"

--- a/browser/arc/arc.go
+++ b/browser/arc/arc.go
@@ -1,0 +1,31 @@
+package arc
+
+import (
+	"context"
+
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+func ReadCookies(ctx context.Context, filename string, filters ...kooky.Filter) ([]*kooky.Cookie, error) {
+	return cookies.SingleRead(cookieStore, filename, filters...).ReadAllCookies(ctx)
+}
+
+func TraverseCookies(filename string, filters ...kooky.Filter) kooky.CookieSeq {
+	return cookies.SingleRead(cookieStore, filename, filters...)
+}
+
+// CookieStore has to be closed with CookieStore.Close() after use.
+func CookieStore(filename string, filters ...kooky.Filter) (kooky.CookieStore, error) {
+	return cookieStore(filename, filters...)
+}
+
+func cookieStore(filename string, filters ...kooky.Filter) (*cookies.CookieJar, error) {
+	s := &chrome.CookieStore{}
+	s.FileNameStr = filename
+	s.BrowserStr = `arc`
+	s.SetSafeStorage(`Arc`, ``, ``)
+
+	return cookies.NewCookieJar(s, filters...), nil
+}

--- a/browser/arc/find.go
+++ b/browser/arc/find.go
@@ -3,6 +3,8 @@
 package arc
 
 import (
+	"os"
+
 	"github.com/browserutils/kooky"
 	"github.com/browserutils/kooky/internal/chrome"
 	chromefind "github.com/browserutils/kooky/internal/chrome/find"
@@ -27,6 +29,15 @@ func (f *arcFinder) FindCookieStores() kooky.CookieStoreSeq {
 				continue
 			}
 			if file == nil {
+				continue
+			}
+			if _, err := os.Stat(file.Path); err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+				if !yield(nil, err) {
+					return
+				}
 				continue
 			}
 			cookieStore := &chrome.CookieStore{

--- a/browser/arc/find.go
+++ b/browser/arc/find.go
@@ -1,0 +1,47 @@
+//go:build darwin && !ios
+
+package arc
+
+import (
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	chromefind "github.com/browserutils/kooky/internal/chrome/find"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+type arcFinder struct{}
+
+var _ kooky.CookieStoreFinder = (*arcFinder)(nil)
+
+func init() {
+	kooky.RegisterFinder(`arc`, &arcFinder{})
+}
+
+func (f *arcFinder) FindCookieStores() kooky.CookieStoreSeq {
+	return func(yield func(kooky.CookieStore, error) bool) {
+		for file, err := range chromefind.FindCookieStoreFiles(arcChromiumRoots, `arc`) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if file == nil {
+				continue
+			}
+			cookieStore := &chrome.CookieStore{
+				DefaultCookieStore: cookies.DefaultCookieStore{
+					BrowserStr:           file.Browser,
+					ProfileStr:           file.Profile,
+					OSStr:                file.OS,
+					IsDefaultProfileBool: file.IsDefaultProfile,
+					FileNameStr:          file.Path,
+				},
+			}
+			cookieStore.SetSafeStorage(`Arc`, ``, ``)
+			if !yield(&cookies.CookieJar{CookieStore: cookieStore}, nil) {
+				return
+			}
+		}
+	}
+}

--- a/browser/arc/find_darwin.go
+++ b/browser/arc/find_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin && !ios
+
+package arc
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func arcChromiumRoots(yield func(string, error) bool) {
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		_ = yield(``, err)
+		return
+	}
+	_ = yield(filepath.Join(cfgDir, `Arc`, `User Data`), nil)
+}

--- a/browser/dia/dia.go
+++ b/browser/dia/dia.go
@@ -1,0 +1,31 @@
+package dia
+
+import (
+	"context"
+
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+func ReadCookies(ctx context.Context, filename string, filters ...kooky.Filter) ([]*kooky.Cookie, error) {
+	return cookies.SingleRead(cookieStore, filename, filters...).ReadAllCookies(ctx)
+}
+
+func TraverseCookies(filename string, filters ...kooky.Filter) kooky.CookieSeq {
+	return cookies.SingleRead(cookieStore, filename, filters...)
+}
+
+// CookieStore has to be closed with CookieStore.Close() after use.
+func CookieStore(filename string, filters ...kooky.Filter) (kooky.CookieStore, error) {
+	return cookieStore(filename, filters...)
+}
+
+func cookieStore(filename string, filters ...kooky.Filter) (*cookies.CookieJar, error) {
+	s := &chrome.CookieStore{}
+	s.FileNameStr = filename
+	s.BrowserStr = `dia`
+	s.SetSafeStorage(`Dia`, ``, ``)
+
+	return cookies.NewCookieJar(s, filters...), nil
+}

--- a/browser/dia/find.go
+++ b/browser/dia/find.go
@@ -1,0 +1,47 @@
+//go:build darwin && !ios
+
+package dia
+
+import (
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/chrome"
+	chromefind "github.com/browserutils/kooky/internal/chrome/find"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+type diaFinder struct{}
+
+var _ kooky.CookieStoreFinder = (*diaFinder)(nil)
+
+func init() {
+	kooky.RegisterFinder(`dia`, &diaFinder{})
+}
+
+func (f *diaFinder) FindCookieStores() kooky.CookieStoreSeq {
+	return func(yield func(kooky.CookieStore, error) bool) {
+		for file, err := range chromefind.FindCookieStoreFiles(diaChromiumRoots, `dia`) {
+			if err != nil {
+				if !yield(nil, err) {
+					return
+				}
+				continue
+			}
+			if file == nil {
+				continue
+			}
+			cookieStore := &chrome.CookieStore{
+				DefaultCookieStore: cookies.DefaultCookieStore{
+					BrowserStr:           file.Browser,
+					ProfileStr:           file.Profile,
+					OSStr:                file.OS,
+					IsDefaultProfileBool: file.IsDefaultProfile,
+					FileNameStr:          file.Path,
+				},
+			}
+			cookieStore.SetSafeStorage(`Dia`, ``, ``)
+			if !yield(&cookies.CookieJar{CookieStore: cookieStore}, nil) {
+				return
+			}
+		}
+	}
+}

--- a/browser/dia/find_darwin.go
+++ b/browser/dia/find_darwin.go
@@ -1,0 +1,17 @@
+//go:build darwin && !ios
+
+package dia
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func diaChromiumRoots(yield func(string, error) bool) {
+	cfgDir, err := os.UserConfigDir()
+	if err != nil {
+		_ = yield(``, err)
+		return
+	}
+	_ = yield(filepath.Join(cfgDir, `Dia`, `User Data`), nil)
+}

--- a/internal/chrome/README.md
+++ b/internal/chrome/README.md
@@ -6,6 +6,7 @@
 |----------------|-----------------------------|-------------------|-----------------------|
 | Chrome         | Chrome Safe Storage         | chrome            | com.google.Chrome     |
 | Chromium       | Chromium Safe Storage       | chromium          | org.chromium.Chromium |
+| Dia            | Dia Safe Storage            | dia               |                       |
 | Brave          | Brave Safe Storage          | brave             |                       |
 | Microsoft Edge | Microsoft Edge Safe Storage | chromium (shared) |                       |
 | Opera          | uses Chromium Safe Storage  | chromium (shared) |                       |

--- a/internal/chrome/README.md
+++ b/internal/chrome/README.md
@@ -7,11 +7,11 @@
 | Chrome         | Chrome Safe Storage         | chrome            | com.google.Chrome     |
 | Chromium       | Chromium Safe Storage       | chromium          | org.chromium.Chromium |
 | Dia            | Dia Safe Storage            | dia               |                       |
+| Arc            | Arc Safe Storage            | arc               |                       |
 | Brave          | Brave Safe Storage          | brave             |                       |
 | Microsoft Edge | Microsoft Edge Safe Storage | chromium (shared) |                       |
 | Opera          | uses Chromium Safe Storage  | chromium (shared) |                       |
 | Vivaldi        | (portal only)               | vivaldi           | com.vivaldi.Vivaldi   |
-| Arc            | Arc Safe Storage            | arc               |                       |
 
 ## SQL schemes of file Cookies, table cookies
 


### PR DESCRIPTION
## Summary

Adds support for the Arc browser on macOS.

Arc stores cookies in a Chromium-style profile under:

`~/Library/Application Support/Arc/User Data`

and uses its own macOS keychain entry:

- account: `Arc`
- service/name: `Arc Safe Storage`

This PR adds:

- a new `browser/arc` package
- automatic Arc finder registration through `browser/all`
- Arc safe storage documentation in `internal/chrome/README.md`
- a small finder fix to skip non-existent cookie DB paths before yielding stores

## Verification

Tested with:

```sh
go test ./...
go test ./browser/arc ./browser/all
go run ./cmd/kooky -b arc -j
```

The local smoke test successfully detected and decrypted cookies from an installed Arc profile on macOS.

## Notes

This change currently adds automatic Arc profile discovery on macOS, which is the platform I was able to verify locally.

Arc on this machine stores cookies in:

`~/Library/Application Support/Arc/User Data/Default/Cookies`

and not in `Default/Network/Cookies`, so the finder now skips missing candidate paths instead of yielding a broken store first.