### PR TITLE
feat: add Ladybird browser cookie support

### DIFF
--- a/browser/all/import.go
+++ b/browser/all/import.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/browserutils/kooky/browser/firefox"
 	_ "github.com/browserutils/kooky/browser/ie"
 	_ "github.com/browserutils/kooky/browser/konqueror"
+	_ "github.com/browserutils/kooky/browser/ladybird"
 	_ "github.com/browserutils/kooky/browser/lynx"
 	_ "github.com/browserutils/kooky/browser/netscape"
 	_ "github.com/browserutils/kooky/browser/opera"

--- a/browser/ladybird/README.md
+++ b/browser/ladybird/README.md
@@ -1,0 +1,31 @@
+# Ladybird
+
+[Ladybird](https://ladybird.org/) is an independent web browser with its own engine.
+
+## Cookie storage
+
+Ladybird stores cookies in a SQLite database at:
+- **Linux:** `~/.local/share/Ladybird/Ladybird.db` (or `$XDG_DATA_HOME/Ladybird/Ladybird.db`)
+- **macOS:** `~/Library/Application Support/Ladybird/Ladybird.db`
+
+## SQL schema of Ladybird.db, table Cookies
+
+```sql
+CREATE TABLE IF NOT EXISTS Cookies (
+    name TEXT,
+    value TEXT,
+    same_site INTEGER CHECK (same_site >= 0 AND same_site <= 3),
+    creation_time INTEGER,
+    last_access_time INTEGER,
+    expiry_time INTEGER,
+    domain TEXT,
+    path TEXT,
+    secure BOOLEAN,
+    http_only BOOLEAN,
+    host_only BOOLEAN,
+    persistent BOOLEAN,
+    PRIMARY KEY(name, domain, path)
+);
+```
+
+Timestamps are stored as Unix epoch **milliseconds**.

--- a/browser/ladybird/cookiestore.go
+++ b/browser/ladybird/cookiestore.go
@@ -1,0 +1,61 @@
+package ladybird
+
+import (
+	"errors"
+	"os"
+
+	"github.com/browserutils/kooky/internal/cookies"
+	"github.com/browserutils/kooky/internal/utils"
+	"github.com/go-sqlite/sqlite3"
+)
+
+type ladybirdCookieStore struct {
+	cookies.DefaultCookieStore
+	Database *sqlite3.DbFile
+	dbFile   *os.File
+}
+
+var _ cookies.CookieStore = (*ladybirdCookieStore)(nil)
+
+func (s *ladybirdCookieStore) Open() error {
+	if s == nil {
+		return errors.New(`cookie store is nil`)
+	}
+	if s.Database != nil {
+		return nil
+	}
+
+	f, err := utils.OpenFile(s.FileNameStr)
+	if err != nil {
+		return err
+	}
+	db, err := sqlite3.OpenFrom(f)
+	if err != nil {
+		f.Close()
+		return err
+	}
+	s.Database = db
+	s.dbFile = f
+
+	return nil
+}
+
+func (s *ladybirdCookieStore) Close() error {
+	if s == nil {
+		return errors.New(`cookie store is nil`)
+	}
+	if s.Database == nil {
+		return nil
+	}
+	err := s.Database.Close()
+	if s.dbFile != nil {
+		if errDB := s.dbFile.Close(); errDB != nil && err == nil {
+			err = errDB
+		}
+	}
+	if err == nil {
+		s.Database = nil
+	}
+
+	return err
+}

--- a/browser/ladybird/find.go
+++ b/browser/ladybird/find.go
@@ -1,0 +1,40 @@
+//go:build !windows && !android && !ios
+
+package ladybird
+
+import (
+	"os"
+
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/cookies"
+)
+
+type ladybirdFinder struct{}
+
+var _ kooky.CookieStoreFinder = (*ladybirdFinder)(nil)
+
+func init() {
+	kooky.RegisterFinder(`ladybird`, &ladybirdFinder{})
+}
+
+func (f *ladybirdFinder) FindCookieStores() kooky.CookieStoreSeq {
+	return func(yield func(kooky.CookieStore, error) bool) {
+		for _, dbPath := range ladybirdCookiePaths() {
+			if _, err := os.Stat(dbPath); err != nil {
+				continue
+			}
+			st := &cookies.CookieJar{
+				CookieStore: &ladybirdCookieStore{
+					DefaultCookieStore: cookies.DefaultCookieStore{
+						BrowserStr:           `ladybird`,
+						IsDefaultProfileBool: true,
+						FileNameStr:          dbPath,
+					},
+				},
+			}
+			if !yield(st, nil) {
+				return
+			}
+		}
+	}
+}

--- a/browser/ladybird/find_darwin.go
+++ b/browser/ladybird/find_darwin.go
@@ -1,0 +1,22 @@
+//go:build darwin && !ios
+
+package ladybird
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func ladybirdCookiePaths() []string {
+	var paths []string
+
+	if dataDir, ok := os.LookupEnv(`XDG_DATA_HOME`); ok && dataDir != `` {
+		paths = append(paths, filepath.Join(dataDir, `Ladybird`, `Ladybird.db`))
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, `Library`, `Application Support`, `Ladybird`, `Ladybird.db`))
+	}
+
+	return paths
+}

--- a/browser/ladybird/find_others.go
+++ b/browser/ladybird/find_others.go
@@ -1,0 +1,7 @@
+//go:build windows || android || ios
+
+package ladybird
+
+func ladybirdCookiePaths() []string {
+	return nil
+}

--- a/browser/ladybird/find_unix.go
+++ b/browser/ladybird/find_unix.go
@@ -1,0 +1,22 @@
+//go:build !windows && !darwin && !android && !ios
+
+package ladybird
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func ladybirdCookiePaths() []string {
+	var paths []string
+
+	if dataDir, ok := os.LookupEnv(`XDG_DATA_HOME`); ok && dataDir != `` {
+		paths = append(paths, filepath.Join(dataDir, `Ladybird`, `Ladybird.db`))
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, `.local`, `share`, `Ladybird`, `Ladybird.db`))
+	}
+
+	return paths
+}

--- a/browser/ladybird/ladybird.go
+++ b/browser/ladybird/ladybird.go
@@ -1,0 +1,109 @@
+package ladybird
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/browserutils/kooky"
+	"github.com/browserutils/kooky/internal/cookies"
+	"github.com/browserutils/kooky/internal/iterx"
+	"github.com/browserutils/kooky/internal/utils"
+)
+
+func ReadCookies(ctx context.Context, filename string, filters ...kooky.Filter) ([]*kooky.Cookie, error) {
+	return cookies.SingleRead(cookieStore, filename, filters...).ReadAllCookies(ctx)
+}
+
+func TraverseCookies(filename string, filters ...kooky.Filter) kooky.CookieSeq {
+	return cookies.SingleRead(cookieStore, filename, filters...)
+}
+
+func (s *ladybirdCookieStore) TraverseCookies(filters ...kooky.Filter) kooky.CookieSeq {
+	if s == nil {
+		return iterx.ErrCookieSeq(errors.New(`cookie store is nil`))
+	}
+	if err := s.Open(); err != nil {
+		return iterx.ErrCookieSeq(err)
+	} else if s.Database == nil {
+		return iterx.ErrCookieSeq(errors.New(`database is nil`))
+	}
+
+	visitor := func(yield func(*kooky.Cookie, error) bool) func(rowId *int64, row utils.TableRow) error {
+		return func(rowId *int64, row utils.TableRow) error {
+			cookie := kooky.Cookie{}
+			var err error
+
+			cookie.Name, err = row.String(`name`)
+			if err != nil {
+				return err
+			}
+
+			cookie.Value, err = row.String(`value`)
+			if err != nil {
+				return err
+			}
+
+			cookie.Domain, err = row.String(`domain`)
+			if err != nil {
+				return err
+			}
+
+			cookie.Path, err = row.String(`path`)
+			if err != nil {
+				return err
+			}
+
+			// Ladybird stores timestamps as Unix milliseconds
+			expiryMs, err := utils.ValueOrFallback[int64](row, `expiry_time`, 0, true)
+			if err != nil {
+				return err
+			}
+			cookie.Expires = time.UnixMilli(expiryMs)
+
+			creationMs, err := utils.ValueOrFallback[int64](row, `creation_time`, 0, true)
+			if err == nil && creationMs > 0 {
+				cookie.Creation = time.UnixMilli(creationMs)
+			}
+
+			cookie.Secure, err = row.Bool(`secure`)
+			if err != nil {
+				return err
+			}
+
+			cookie.HttpOnly, err = row.Bool(`http_only`)
+			if err != nil {
+				return err
+			}
+
+			cookie.Browser = s
+
+			if !iterx.CookieFilterYield(context.Background(), &cookie, nil, yield, filters...) {
+				return iterx.ErrYieldEnd
+			}
+
+			return nil
+		}
+	}
+	seq := func(yield func(*kooky.Cookie, error) bool) {
+		err := utils.VisitTableRows(s.Database, `Cookies`, map[string]string{}, visitor(yield))
+		if err != nil && !errors.Is(err, iterx.ErrYieldEnd) {
+			yield(nil, err)
+		}
+	}
+
+	return seq
+}
+
+// CookieStore has to be closed with CookieStore.Close() after use.
+func CookieStore(filename string, filters ...kooky.Filter) (kooky.CookieStore, error) {
+	return cookieStore(filename, filters...)
+}
+
+func cookieStore(filename string, filters ...kooky.Filter) (*cookies.CookieJar, error) {
+	s := &ladybirdCookieStore{}
+	s.FileNameStr = filename
+	s.BrowserStr = `ladybird`
+
+	return cookies.NewCookieJar(s, filters...), nil
+}


### PR DESCRIPTION
## Summary

Add a new browser module for the [Ladybird](https://ladybird.org/) web browser.

Ladybird is an independent browser with its own rendering engine (not a Gecko/Chromium fork). It stores cookies in a SQLite database (`Ladybird.db`) with its own schema — a `Cookies` table with timestamps as Unix milliseconds, domains without leading dots, and a separate `host_only` boolean.

## Changes

- **`browser/ladybird/cookiestore.go`** — SQLite-backed CookieStore implementation (same pattern as epiphany)
- **`browser/ladybird/ladybird.go`** — Cookie reader using `VisitTableRows` on the `Cookies` table, mapping Ladybird's schema to `kooky.Cookie`
- **`browser/ladybird/find.go`** — Finder registration + auto-discovery
- **`browser/ladybird/find_darwin.go`** — macOS path: `~/Library/Application Support/Ladybird/Ladybird.db`
- **`browser/ladybird/find_unix.go`** — Linux path: `~/.local/share/Ladybird/Ladybird.db`
- **`browser/ladybird/find_others.go`** — Stub for unsupported platforms
- **`browser/ladybird/README.md`** — Schema documentation
- **`browser/all/import.go`** — Register ladybird in the all-browsers import

## Ladybird Cookie Schema

```sql
CREATE TABLE IF NOT EXISTS Cookies (
    name TEXT,
    value TEXT,
    same_site INTEGER,
    creation_time INTEGER,   -- Unix milliseconds
    last_access_time INTEGER,
    expiry_time INTEGER,     -- Unix milliseconds
    domain TEXT,
    path TEXT,
    secure BOOLEAN,
    http_only BOOLEAN,
    host_only BOOLEAN,
    persistent BOOLEAN,
    PRIMARY KEY(name, domain, path)
);
```

No new dependencies — uses the existing `go-sqlite/sqlite3` reader and `internal/utils.VisitTableRows`.